### PR TITLE
SWI-2827 Add Repo to Service Catalog

### DIFF
--- a/.bandwidth/catalog-info.yaml
+++ b/.bandwidth/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  schemaVersion: v1.0.0
+  name: build-notify-slack-action-location
+  description: Links to additional entities in the build-notify-slack-action repository.
+  annotations:
+    github.com/project-slug: Bandwidth/build-notify-slack-action
+spec:
+  targets:
+    - ./component.yaml

--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  schemaVersion: v1.0.0
+  name: build-notify-slack-action
+  description: An action that notifies Slack of the build status.
+  annotations:
+    github.com/project-slug: Bandwidth/build-notify-slack-action
+  organization: BW
+  costCenter: UNKNOWN
+spec:
+  type: GitHub Action
+  owner: github/band-swi
+  lifecycle: Available


### PR DESCRIPTION
Auto-generated by the Backstage Service Catalog. Adds a `catalog-info.yaml` Location and `component.yaml` Component to represent this repository.